### PR TITLE
[GITHUB-3] Add thin pool config, if requested.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,11 @@
 ---
 
 docker:
+  package_version:
+    thin_provisioning_tools: 0.5.6*
   repo_keyserver: hkp://keyserver.ubuntu.com:80
   repo_key_id: 0EBFCD88
   repo: "deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
+  thin_pool_device: ~
   version: ~
   workspace_user: ~

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,25 @@
+---
+
+- name: reload docker
+  become: yes
+  service:
+    name: docker
+    state: reloaded
+
+- name: restart docker
+  become: yes
+  service:
+    name: docker
+    state: restarted
+
+- name: start docker
+  become: yes
+  service:
+    name: docker
+    state: started
+
+- name: stop docker
+  become: yes
+  service:
+    name: docker
+    state: stopped

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,6 +1,24 @@
 ---
 
-- name: Ensure Docker service is restarted
+- name: Add thinpool configuration
+  become: yes
+  template:
+    dest: /etc/docker/daemon.json
+    group: root
+    mode: 0444
+    owner: root
+    src: daemon.json.j2
+  when: docker.thin_pool_device is not none
+  register: docker_thinpool_config
+
+- name: Ensure Docker service is restarted when thinpool changed
+  become: yes
+  service:
+    name: docker
+    state: restarted
+  when: docker_thinpool_config.changed
+
+- name: Ensure Docker service starts at boot
   become: yes
   service:
     name: docker

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -8,8 +8,18 @@
     - apt-transport-https
     - ca-certificates
     - curl
-    - "linux-image-extra-{{ ansible_kernel }}"
-    - linux-image-extra-virtual
+
+- name: Install thin-provisioning-tools if required
+  become: yes
+  apt:
+    name: "thin-provisioning-tools={{ docker.package_version.thin_provisioning_tools }}"
+  when: docker.thin_pool_device is not none
+
+- name: Install kernel extras
+  become: yes
+  apt:
+    name: "linux-image-extra-{{ ansible_kernel }}"
+  when: ansible_distribution_release == "trusty"
 
 - name: Add Docker gpg key
   become: yes
@@ -29,6 +39,15 @@
   become: yes
   apt:
     name: "{{ 'docker-ce=' + docker.version if docker.version else 'docker-ce' }}"
+
+- name: Create /etc/docker
+  become: yes
+  file:
+    group: root
+    mode: 0755
+    owner: root
+    path: /etc/docker
+    state: directory
 
 - name: Add workspace user to docker group
   become: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,13 @@
 ---
 
+- name: Assert supported options
+  assert:
+    that:
+     - docker.thin_pool_device is none
+  when: ansible_distribution_release == "trusty"
+  tags:
+    - always
+
 - name: Install Docker
   include: install.yml
   tags:

--- a/templates/daemon.json.j2
+++ b/templates/daemon.json.j2
@@ -1,0 +1,6 @@
+{
+  "storage-driver": "devicemapper",
+  "storage-opts": [
+    "dm.directlvm_device={{ docker.thin_pool_device }}"
+  ]
+}


### PR DESCRIPTION
This code adds the option to enable a "thin pool" configuration in docker. It uses a secondary EBS volume to store the images and containers for the docker instance.
The thin pool driver does not work easily with trusty. Asserts have been put in place to ensure the new code only runs on xenial.