### PR TITLE
[GITHUB-5] enable definition of the default bridge IP range

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 
 docker:
+  bridge_ip: ~
   package_version:
     thin_provisioning_tools: 0.5.6*
   repo_keyserver: hkp://keyserver.ubuntu.com:80

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Add thinpool configuration
+- name: Add a docker configuration file
   become: yes
   template:
     dest: /etc/docker/daemon.json
@@ -8,15 +8,14 @@
     mode: 0444
     owner: root
     src: daemon.json.j2
-  when: docker.thin_pool_device is not none
-  register: docker_thinpool_config
+  register: docker_config_file
 
-- name: Ensure Docker service is restarted when thinpool changed
+- name: Ensure Docker service is restarted with configuration changes
   become: yes
   service:
     name: docker
     state: restarted
-  when: docker_thinpool_config.changed
+  when: docker_config_file.changed
 
 - name: Ensure Docker service starts at boot
   become: yes

--- a/templates/daemon.json.j2
+++ b/templates/daemon.json.j2
@@ -1,6 +1,11 @@
 {
+{% if docker.thin_pool_device is not none %}
   "storage-driver": "devicemapper",
   "storage-opts": [
     "dm.directlvm_device={{ docker.thin_pool_device }}"
-  ]
+  ]{% if docker.bridge_ip is not none %},{% endif %}
+{% endif %}
+{% if docker.bridge_ip is not none %}
+  "bip": "{{ docker.bridge_ip }}"
+{% endif %}
 }


### PR DESCRIPTION
In order minimise the risk of IP range collisions, we need to be able to change docker's default range.
This PR adds a bridge_ip parameter, which defaults to the docker default.
Changing this parameter will change the range docker uses.